### PR TITLE
Update pastie to get the paste from the correct URL

### DIFF
--- a/lib/Pastie.py
+++ b/lib/Pastie.py
@@ -12,7 +12,7 @@ class PastiePaste(Paste):
     def __init__(self, id):
         self.id = id
         self.headers = None
-        self.url = 'http://pastie.org/pastes/' + self.id + '/text'
+        self.url = 'http://pastie.org/pastes/' + self.id + '/download'
         super(PastiePaste, self).__init__()
 
 


### PR DESCRIPTION
'/text' returns HTML that formats the text to look correct in the browser, but is in fact not 'raw' format.

'/download' returns the file as-is, and is what we want. :-)
