### PR TITLE
Add regex for Telegram Bot API keys

### DIFF
--- a/lib/Paste.py
+++ b/lib/Paste.py
@@ -60,6 +60,8 @@ class Paste(object):
             self.type = 'pgp_private'
         if regexes['ssh_private'].search(self.text):
             self.type = 'ssh_private'
+        if regexes['telegram_bot'].search(self.text):
+            self.type = 'telegram_bot'
         # if regexes['juniper'].search(self.text): self.type = 'Juniper'
         for regex in regexes['banlist']:
             if regex.search(self.text):

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -61,6 +61,8 @@ def build_tweet(paste):
             tweet += ' Possible ' + paste.type + ' configuration'
         elif paste.type == 'ssh_private':
             tweet += ' Possible SSH private key'
+        elif paste.type == 'telegram_bot':
+            tweet += ' Possible Telegram Bot API key'
         elif paste.type == 'honeypot':
             tweet += ' Dionaea Honeypot Log'
         elif paste.type == 'pgp_private':

--- a/lib/regexes.py
+++ b/lib/regexes.py
@@ -12,6 +12,7 @@ regexes = {
     'honeypot': re.compile(r'<dionaea\.capture>', re.I),
     'pgp_private': re.compile(r'BEGIN PGP PRIVATE', re.I),
     'ssh_private': re.compile(r'BEGIN RSA PRIVATE', re.I),
+    'telegram_bot': re.compile(r'\d{9}:[0-9A-Za-z_-]{35}'),
     'db_keywords': [
 		re.compile(r'((customers?|email|users?|members?|acc(?:oun)?ts?)([-_|/\s]?(address|name|id[^")a-zA-Z0-9_]|[-_:|/\\])))', re.I),
         re.compile(r'((\W?pass(wor)?d|hash)[\s|:])', re.I),


### PR DESCRIPTION
[Telegram](https://telegram.org) provides its [Bot API](https://core.telegram.org/bots/) for users to create chatbots. I've seen the amount of bots grow a lot since the API was released, and I'm pretty sure Pastebin has a lot of their API keys. (I have accidentally posted some myself, not in public pastes though.) So, here's a patch to add matching for them.

The regex used is `\d{9}:[0-9A-Za-z_-]{35}`, which shouldn't produce many false positives, and matches all API keys I have seen.
